### PR TITLE
Add attachments, and incident updates onto incidents stream

### DIFF
--- a/model/external_resource_v1.go
+++ b/model/external_resource_v1.go
@@ -1,0 +1,31 @@
+package model
+
+import "github.com/incident-io/singer-tap/client"
+
+type externalResourceV1 struct{}
+
+var ExternalResourceV1 externalResourceV1
+
+func (externalResourceV1) Schema() Property {
+	return Property{
+		Types: []string{"object"},
+		Properties: map[string]Property{
+			"external_id": {
+				Types: []string{"string"},
+			},
+			"permalink": {
+				Types: []string{"string"},
+			},
+			"resource_type": {
+				Types: []string{"string"},
+			},
+			"title": {
+				Types: []string{"string"},
+			},
+		},
+	}
+}
+
+func (externalResourceV1) Serialize(input client.ExternalResourceV1) map[string]any {
+	return DumpToMap(input)
+}

--- a/model/incident_attachment_v1.go
+++ b/model/incident_attachment_v1.go
@@ -1,0 +1,30 @@
+package model
+
+import "github.com/incident-io/singer-tap/client"
+
+type incidentAttachmentV1 struct{}
+
+var IncidentAttachmentV1 incidentAttachmentV1
+
+func (incidentAttachmentV1) Schema() Property {
+	return Property{
+		Types: []string{"object"},
+		Properties: map[string]Property{
+			"id": {
+				Types: []string{"string"},
+			},
+			"incident_id": {
+				Types: []string{"string"},
+			},
+			"resource": ExternalResourceV1.Schema(),
+		},
+	}
+}
+
+func (incidentAttachmentV1) Serialize(input client.IncidentAttachmentV1) map[string]any {
+	return map[string]any{
+		"id":          input.Id,
+		"incident_id": input.IncidentId,
+		"resource":    ExternalResourceV1.Serialize(input.Resource),
+	}
+}

--- a/model/incident_v2.go
+++ b/model/incident_v2.go
@@ -25,6 +25,8 @@ func (incidentV2) Schema() Property {
 			"creator":                   ActorV2.Schema(),
 			"custom_field_entries":      ArrayOf(CustomFieldEntryV1.Schema()),
 			"external_issue_reference":  Optional(ExternalIssueReferenceV2.Schema()),
+			"attachments":               Optional(ArrayOf(IncidentAttachmentV1.Schema())),
+			"updates":                   Optional(ArrayOf(IncidentUpdateV2.Schema())),
 			"incident_role_assignments": ArrayOf(IncidentRoleAssignmentV1.Schema()),
 			"incident_status":           IncidentStatusV1.Schema(),
 			"incident_timestamp_values": Optional(ArrayOf(IncidentTimestampWithValueV2.Schema())),
@@ -75,7 +77,25 @@ func (incidentV2) Schema() Property {
 	}
 }
 
-func (incidentV2) Serialize(input client.IncidentV2) map[string]any {
+func (incidentV2) Serialize(
+	input client.IncidentV2,
+	incidentAttachments []client.IncidentAttachmentV1,
+	incidentUpdates []client.IncidentUpdateV2,
+) map[string]any {
+	var attachments []map[string]any
+	if len(incidentAttachments) > 0 {
+		attachments = lo.Map(incidentAttachments, func(attachment client.IncidentAttachmentV1, _ int) map[string]any {
+			return IncidentAttachmentV1.Serialize(attachment)
+		})
+	}
+
+	var updates []map[string]any
+	if len(incidentUpdates) > 0 {
+		updates = lo.Map(incidentUpdates, func(update client.IncidentUpdateV2, _ int) map[string]any {
+			return IncidentUpdateV2.Serialize(update)
+		})
+	}
+
 	return map[string]any{
 		"id":       input.Id,
 		"name":     input.Name,
@@ -85,6 +105,8 @@ func (incidentV2) Serialize(input client.IncidentV2) map[string]any {
 			return CustomFieldEntryV1.Serialize(entry)
 		}),
 		"external_issue_reference": ExternalIssueReferenceV2.Serialize(input.ExternalIssueReference),
+		"attachments":              attachments,
+		"updates":                  updates,
 		"incident_role_assignments": lo.Map(input.IncidentRoleAssignments, func(assignment client.IncidentRoleAssignmentV1, _ int) map[string]any {
 			return IncidentRoleAssignmentV1.Serialize(assignment)
 		}),


### PR DESCRIPTION
The attachments API is per incident, so makes sense to nest this information into the incident schema itself as we go.

The updates we have a separate table but we can also insert them nested into the incident itself - you can literally basically do 1 query for everything then!

Shot of an attachment on an incident:

<img width="1583" alt="Screenshot 2023-10-19 at 12 56 37" src="https://github.com/incident-io/singer-tap/assets/35259000/37cdb977-fc41-45ee-9b1b-968601a1f30f">

Shot of some updates:
<img width="1032" alt="Screenshot 2023-10-19 at 14 51 05" src="https://github.com/incident-io/singer-tap/assets/35259000/edd3ea2c-7d51-42fc-92b5-72bde91532c2">


