### PR TITLE
Fix invalid schemas and timestamp formatting

### DIFF
--- a/model/action_v2.go
+++ b/model/action_v2.go
@@ -23,7 +23,7 @@ func (actionV2) Schema() Property {
 				Types: []string{"string"},
 			},
 			"assignee":     Optional(UserV1.Schema()),
-			"completed_at": DateTime.Schema(),
+			"completed_at": Optional(DateTime.Schema()),
 			"created_at":   DateTime.Schema(),
 			"updated_at":   DateTime.Schema(),
 		},

--- a/model/follow_up_v2.go
+++ b/model/follow_up_v2.go
@@ -28,7 +28,7 @@ func (followUpV2) Schema() Property {
 				Types: []string{"string", "null"},
 			},
 			"external_issue_reference": Optional(ExternalIssueReferenceV2.Schema()),
-			"completed_at":             DateTime.Schema(),
+			"completed_at":             Optional(DateTime.Schema()),
 			"created_at":               DateTime.Schema(),
 			"updated_at":               DateTime.Schema(),
 		},

--- a/model/incident_role_v1.go
+++ b/model/incident_role_v1.go
@@ -28,7 +28,7 @@ func (incidentRoleV1) Schema() Property {
 			"role_type": {
 				Types: []string{"string"},
 			},
-			"short_form": {
+			"shortform": {
 				Types: []string{"string"},
 			},
 			"created_at": DateTime.Schema(),

--- a/model/incident_role_v2.go
+++ b/model/incident_role_v2.go
@@ -29,7 +29,7 @@ func (incidentRoleV2) Schema() Property {
 			"role_type": {
 				Types: []string{"string"},
 			},
-			"short_form": {
+			"shortform": {
 				Types: []string{"string"},
 			},
 			"created_at": DateTime.Schema(),

--- a/tap/tap.go
+++ b/tap/tap.go
@@ -31,7 +31,7 @@ func Sync(ctx context.Context, logger kitlog.Logger, ol *OutputLogger, cl *clien
 			return err
 		}
 
-		timeExtracted := time.Now().Format(time.RFC3339)
+		timeExtracted := time.Now().UTC().Format(time.RFC3339)
 		logger.Log("msg", "loading records", "time_extracted", timeExtracted)
 
 		records, err := stream.GetRecords(ctx, logger, cl)


### PR DESCRIPTION
While testing running this tap against stitch itself there were a few validations that cropped up - mainly around timestamps that actually need to be optional but are not.

There was a typo on another field also which has been corrected.

The final change was to the timestamp for when a record has been emitted. The stitch documentation says:

```
This should be an RFC3339 formatted date-time, like "2017-11-20T16:45:33.000Z".
```

What they don't say is that their python library demands it's locked to UTC e.g. you cannot have an actually valid RFC3339 timestamp such as:

`time_extracted=2023-10-22T19:28:41+01:00`

which has the timezone present. Why is this? Who knows - it's a timestamp, it's valid, it has timezone information in it that would let you calculate UTC.

So for now lets just emit with things cast to UTC first.