### PR TITLE
fix: incident timestamp value is optional for most cases

### DIFF
--- a/model/incident_timestamp_value_v2.go
+++ b/model/incident_timestamp_value_v2.go
@@ -10,7 +10,7 @@ func (incidentTimestampValueV2) Schema() Property {
 	return Property{
 		Types: []string{"object"},
 		Properties: map[string]Property{
-			"value": DateTime.Schema(),
+			"value": Optional(DateTime.Schema()),
 		},
 	}
 }


### PR DESCRIPTION
frequently getting errors like this:

```
jsonschema.exceptions.ValidationError: None is not of type 'string'

Failed validating 'type' in schema['properties']['incident_timestamp_values']['items']['properties']['value']['properties']['value']:
    {'format': 'date-time', 'type': ['string']}

On instance['incident_timestamp_values'][11]['value']['value']:
    None
```

which can be fixed by making the timestamp optional in the schema. most of the timestamps I know of in incident.io except for reported at are always optional?