### PR TITLE
fix: should not duplicate null for optional types - v2

### DIFF
--- a/model/schema.go
+++ b/model/schema.go
@@ -75,6 +75,11 @@ func DumpToMap(input interface{}) map[string]any {
 }
 
 func Optional(p Property) Property {
+	for _, val := range p.Types {
+		if val == "null" {
+			return p
+		}
+	}
 	p.Types = append(p.Types, "null")
 	return p
 }


### PR DESCRIPTION
External issue reference on follow ups are optional, but they are both Optional() in the follow up spec and explicitly defined as {object, null} in their own spec.

This apparently (?) leads to errors like the following with taps doing particular schema validations e.g. anyOf (target-gsheet)

```
Exception: ['object', 'null', 'null'] is not valid under any of the given schemas

Failed validating 'anyOf' in schema['properties']['properties']['additionalProperties']['properties']['type']:
    {'anyOf': [{'$ref': '#/definitions/simpleTypes'},
               {'items': {'$ref': '#/definitions/simpleTypes'},
                'minItems': 1,
                'type': 'array',
                'uniqueItems': True}]}

On instance['properties']['external_issue_reference']['type']:
    ['object', 'null', 'null']
```

which can be fixed by passing a unique list of schemas to validations like anyOf (apparently? unclear why you'd require array item uniquess from the validator side, but this PR works for me anyway).

alternatively, you can remove null from types in external issue reference and make it optional everywhere required. see https://github.com/incident-io/singer-tap/pull/30