### PR TITLE
fix: should not duplicate null for optional types - v1

### DIFF
--- a/model/external_issue_reference_v2.go
+++ b/model/external_issue_reference_v2.go
@@ -8,7 +8,7 @@ var ExternalIssueReferenceV2 externalIssueReferenceV2
 
 func (externalIssueReferenceV2) Schema() Property {
 	return Property{
-		Types: []string{"object", "null"},
+		Types: []string{"object"},
 		Properties: map[string]Property{
 			"issue_name": {
 				Types: []string{"string"},


### PR DESCRIPTION
External issue reference on follow ups are optional, but they are both Optional() in the follow up spec and explicitly defined as {object, null} in their own spec.

This apparently (?) leads to errors like the following with taps doing particular schema validations e.g. anyOf (target-gsheet)

```
Exception: ['object', 'null', 'null'] is not valid under any of the given schemas

Failed validating 'anyOf' in schema['properties']['properties']['additionalProperties']['properties']['type']:
    {'anyOf': [{'$ref': '#/definitions/simpleTypes'},
               {'items': {'$ref': '#/definitions/simpleTypes'},
                'minItems': 1,
                'type': 'array',
                'uniqueItems': True}]}

On instance['properties']['external_issue_reference']['type']:
    ['object', 'null', 'null']
```

which can be fixed by passing a unique list of schemas to validations like anyOf (apparently? unclear why you'd require array item uniquess from the validator side, but this PR works for me anyway).

alternatively, you can ensure the helper has "set" not "list" behavior, see https://github.com/incident-io/singer-tap/pull/29